### PR TITLE
Fix MPT verify bug

### DIFF
--- a/contracts/contracts/lib/MPT.sol
+++ b/contracts/contracts/lib/MPT.sol
@@ -168,7 +168,7 @@ library MPT {
         pure internal returns(bytes memory)
     {
         uint256 slots = length / 32;
-        uint256 rest = (length % 32) * 8;
+        uint256 rest = 256 - (length % 32) * 8;
         uint256 pos = 32;
         uint256 si = 0;
         uint256 source;

--- a/contracts/contracts/lib/MPT.sol
+++ b/contracts/contracts/lib/MPT.sol
@@ -99,8 +99,8 @@ library MPT {
         if (prefix == 2) {
             // leaf even
             uint256 length = nodekey.length - 1;
-            bytes memory actualKey = sliceTransform(nodekey, 33, length, false);
-            bytes memory restKey = sliceTransform(data.key, 32 + data.keyIndex, length, false);
+            bytes memory actualKey = sliceTransform(nodekey, 1, length, false);
+            bytes memory restKey = sliceTransform(data.key, data.keyIndex, length, false);
             if (keccak256(data.expectedValue) == keccak256(nodevalue)) {
                 if (keccak256(actualKey) == keccak256(restKey)) return true;
                 if (keccak256(expandKeyEven(actualKey)) == keccak256(restKey)) return true;
@@ -108,8 +108,8 @@ library MPT {
         }
         else if (prefix == 3) {
             // leaf odd
-            bytes memory actualKey = sliceTransform(nodekey, 32, nodekey.length, true);
-            bytes memory restKey = sliceTransform(data.key, 32 + data.keyIndex, data.key.length - data.keyIndex, false);
+            bytes memory actualKey = sliceTransform(nodekey, 0, nodekey.length, true);
+            bytes memory restKey = sliceTransform(data.key, data.keyIndex, data.key.length - data.keyIndex, false);
             if (keccak256(data.expectedValue) == keccak256(nodevalue)) {
                 if (keccak256(actualKey) == keccak256(restKey)) return true;
                 if (keccak256(expandKeyOdd(actualKey)) == keccak256(restKey)) return true;
@@ -118,8 +118,8 @@ library MPT {
         else if (prefix == 0) {
             // extension even
             uint256 extensionLength = nodekey.length - 1;
-            bytes memory shared_nibbles = sliceTransform(nodekey, 33, extensionLength, false);
-            bytes memory restKey = sliceTransform(data.key, 32 + data.keyIndex, extensionLength, false);
+            bytes memory shared_nibbles = sliceTransform(nodekey, 1, extensionLength, false);
+            bytes memory restKey = sliceTransform(data.key, data.keyIndex, extensionLength, false);
             if (
                 keccak256(shared_nibbles) == keccak256(restKey) ||
                 keccak256(expandKeyEven(shared_nibbles)) == keccak256(restKey)
@@ -134,8 +134,8 @@ library MPT {
         else if (prefix == 1) {
             // extension odd
             uint256 extensionLength = nodekey.length;
-            bytes memory shared_nibbles = sliceTransform(nodekey, 32, extensionLength, true);
-            bytes memory restKey = sliceTransform(data.key, 32 + data.keyIndex, extensionLength, false);
+            bytes memory shared_nibbles = sliceTransform(nodekey, 0, extensionLength, true);
+            bytes memory restKey = sliceTransform(data.key, data.keyIndex, extensionLength, false);
             if (
                 keccak256(shared_nibbles) == keccak256(restKey) ||
                 keccak256(expandKeyEven(shared_nibbles)) == keccak256(restKey)


### PR DESCRIPTION
More 32 bytes jump when calling sliceTransform, as the pos start from 32 in sliceTransform.